### PR TITLE
Updating equidock repo to latest packages - dgl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,31 @@
-# python==3.9.10
-# rdkit==2021.09.4
-numpy==1.22.1
-torch==1.10.2
-dgl==0.7.0
-biopandas==0.2.8
-POT==0.7.0
-dgllife==0.2.8
-joblib==1.1.0
+biopandas==0.4.1
+certifi==2023.7.22
+charset-normalizer==3.2.0
+cloudpickle==2.2.1
+dgl==1.1.2
+dgllife==0.3.2
+future==0.18.3
+hyperopt==0.2.7
+idna==3.4
+joblib==1.3.2
+networkx==3.1
+numpy==1.26.0
+packaging==23.1
+pandas==2.1.1
+Pillow==10.0.1
+POT==0.9.1
+psutil==5.9.5
+py4j==0.10.9.7
+python-dateutil==2.8.2
+pytz==2023.3.post1
+rdkit==2023.3.3
+requests==2.31.0
+scikit-learn==1.3.1
+scipy==1.11.2
+six==1.16.0
+threadpoolctl==3.2.0
+torch==1.12.0
+tqdm==4.66.1
+typing_extensions @ file:///croot/typing_extensions_1690297465030/work
+tzdata==2023.3
+urllib3==2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ tqdm==4.66.1
 typing_extensions @ file:///croot/typing_extensions_1690297465030/work
 tzdata==2023.3
 urllib3==2.0.5
+chardet=5.2.0

--- a/src/model/rigid_docking_model.py
+++ b/src/model/rigid_docking_model.py
@@ -271,15 +271,15 @@ class IEGMN_Layer(nn.Module):
                 self.log(torch.max(hetero_graph.edges['ll'].data['x_moment']), 'data[x_moment] = (x_i - x_j) * \phi^x(m_{i->j})')
 
 
-            hetero_graph.update_all(fn.copy_edge('x_moment', 'm'), fn.mean('m', 'x_update'),
+            hetero_graph.update_all(fn.copy_e('x_moment', 'm'), fn.mean('m', 'x_update'),
                                     etype=('ligand', 'll', 'ligand'))
-            hetero_graph.update_all(fn.copy_edge('x_moment', 'm'), fn.mean('m', 'x_update'),
+            hetero_graph.update_all(fn.copy_e('x_moment', 'm'), fn.mean('m', 'x_update'),
                                     etype=('receptor', 'rr', 'receptor'))
 
 
-            hetero_graph.update_all(fn.copy_edge('msg', 'm'), fn.mean('m', 'aggr_msg'),
+            hetero_graph.update_all(fn.copy_e('msg', 'm'), fn.mean('m', 'aggr_msg'),
                                     etype=('ligand', 'll', 'ligand'))
-            hetero_graph.update_all(fn.copy_edge('msg', 'm'), fn.mean('m', 'aggr_msg'),
+            hetero_graph.update_all(fn.copy_e('msg', 'm'), fn.mean('m', 'aggr_msg'),
                                     etype=('receptor', 'rr', 'receptor'))
 
 


### PR DESCRIPTION
Updating packages to latest (as of sep 2023, using Python 3.10.13) for using current version of various dependencies. No new dependencies added. With these changes, the inference command `python src/inference_rigid.py` can be run successfully with GPU. Since the python code is not installed as a package, ensure to add the root folder to PYTHONPATH using something like `export PYTHONPATH="${PYTHONPATH}:/home/somewhere/equidock_public"`